### PR TITLE
Wrapped card-front into a block to fix transition

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,6 +137,11 @@ body {
     height: 100%;
     position: absolute;
     width: 100%; }
+  .content .card-front-wrapper {
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    position: absolute;  }
   .content .card-front {
     -webkit-transform: perspective(1000) rotateX(0);
     -moz-transform: perspective(1000) rotateX(0);

--- a/index.html
+++ b/index.html
@@ -21,9 +21,11 @@ Best view in full preview.
 
 	<!-- 1 -->
 	<li>
-		<div class="card-front">
-			<h2><b>What is Lorem ipsum?</b></h2>
-			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis condimentum.</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>What is Lorem ipsum?</b></h2>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis condimentum.</p>
+			</div>
 		</div>
 		<div class="card-back">
       <h2><b>Click here</b></h2>
@@ -36,9 +38,11 @@ Best view in full preview.
 	</li>
 
 	<li>
-		<div class="card-front">
-			<h2><b>Contrary to popular belief</b></h2>
-			<p>Aenean imperdiet odio id dictum elementum. Donec vitae.</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Contrary to popular belief</b></h2>
+				<p>Aenean imperdiet odio id dictum elementum. Donec vitae.</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -51,9 +55,11 @@ Best view in full preview.
 	</li>
 
 	<li>
-		<div class="card-front">
-			<h2><b>In vulputate sem a arcu semper</b></h2>
-			<p>Donec ac ipsum quis arcu sagittis placerat. Etiam augue felis.</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>In vulputate sem a arcu semper</b></h2>
+				<p>Donec ac ipsum quis arcu sagittis placerat. Etiam augue felis.</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -68,9 +74,11 @@ Best view in full preview.
 
 	<!-- 2 -->
 	<li>
-		<div class="card-front">
-			<h2><b>Etiam quis sapien interdum</b></h2>
-			<p>Praesent sodales et tellus eu euismod. Suspendisse lobortis.</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Etiam quis sapien interdum</b></h2>
+				<p>Praesent sodales et tellus eu euismod. Suspendisse lobortis.</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -83,9 +91,11 @@ Best view in full preview.
 	</li>
 
 	<li>
-		<div class="card-front">
-			<h2><b>Vivamus metus massa</b></h2>
-			<p> Phasellus vel nulla bibendum dolor pellentesque lacinia</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Vivamus metus massa</b></h2>
+				<p> Phasellus vel nulla bibendum dolor pellentesque lacinia</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -97,9 +107,11 @@ Best view in full preview.
 		</div>
 	</li>
 	<li>
-		<div class="card-front">
-			<h2><b>Integer consequat vitae turpis</b></h2>
-			<p>  Nam id pretium arcu, at vestibulum mauris. Curabitur.</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Integer consequat vitae turpis</b></h2>
+				<p>  Nam id pretium arcu, at vestibulum mauris. Curabitur.</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -114,9 +126,11 @@ Best view in full preview.
 
 	<!-- 3 -->
 	<li>
-		<div class="card-front">
-			<h2><b>Duis tellus dui vehicula</b></h2>
-			<p>Morbi ac scelerisque magna, at tincidunt est vivamus</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Duis tellus dui vehicula</b></h2>
+				<p>Morbi ac scelerisque magna, at tincidunt est vivamus</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -129,9 +143,11 @@ Best view in full preview.
 	</li>
 
 	<li>
-		<div class="card-front">
-			<h2><b>Ligula nulla tempus sem</b></h2>
-			<p>In iaculis purus sit amet auctor mollis, lorem ipsum dolor sit</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Ligula nulla tempus sem</b></h2>
+				<p>In iaculis purus sit amet auctor mollis, lorem ipsum dolor sit</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>
@@ -144,9 +160,11 @@ Best view in full preview.
 	</li>
 
 	<li>
-		<div class="card-front">
-			<h2><b>Class aptent taciti sociosqu</b></h2>
-			<p>Cultrices posuere cubilia Curae; Quisque consectetur tortor</p>
+		<div class="card-front-wrapper">
+			<div class="card-front">
+				<h2><b>Class aptent taciti sociosqu</b></h2>
+				<p>Cultrices posuere cubilia Curae; Quisque consectetur tortor</p>
+			</div>
 		</div>
 		<div class="card-back">
 			<h2><b>Click here</b></h2>


### PR DESCRIPTION
Originally, if you move the cursor horizontally from one block to another in the bottom part of the blocks, flipping not going smothly because the card-front block sliding under the cursor while animation happening. Wrapping this block into another block with propety overflow: hidden helped to resolve the issue.